### PR TITLE
Fix license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,4 +191,4 @@ setTimeout(function () {
 
 #License
 
-[VOL](veryopenlicense.com)
+[VOL](http://veryopenlicense.com)


### PR DESCRIPTION
If your link doesn't contain the scheme name (e.g. `http://`) it gets interpreted in the browser as a relative path instead of a domain (hover over the old link to see).
